### PR TITLE
callback type in credit card request

### DIFF
--- a/coreapi/request.go
+++ b/coreapi/request.go
@@ -62,6 +62,9 @@ type CreditCardDetails struct {
 
 	// PointRedeemAmount For Mandiri Point, you can only do Full Redemption.(use -1 for Full Redemption)
 	PointRedeemAmount int64 `json:"point_redeem_amount,omitempty"`
+
+	// Determines how the transaction status is updated to the merchant frontend. Possible values are js_event (default) and form
+	CallbackType string `json:"callback_type,omitempty"`
 }
 
 // BankTransferDetails : Represent bank_transfer detail

--- a/example/simple/coreapi/sample.go
+++ b/example/simple/coreapi/sample.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/midtrans/midtrans-go"
-	"github.com/midtrans/midtrans-go/coreapi"
-	"github.com/midtrans/midtrans-go/example"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+
+	"github.com/midtrans/midtrans-go"
+	"github.com/midtrans/midtrans-go/coreapi"
+	"github.com/midtrans/midtrans-go/example"
 )
 
 var c coreapi.Client
@@ -45,7 +46,7 @@ func chargeTransactionWithMap() {
 
 func getCardToken() string {
 	midtrans.ClientKey = example.SandboxClientKey2
-	resp, err := coreapi.CardToken("4105058689481467", 12, 2021, "123")
+	resp, err := coreapi.CardToken("4105058689481467", 12, 2025, "123")
 	if err != nil {
 		fmt.Println("Error get card token", err.GetMessage())
 	}
@@ -55,7 +56,7 @@ func getCardToken() string {
 
 func registerCard() {
 	midtrans.ClientKey = example.SandboxClientKey2
-	resp, err := coreapi.RegisterCard("4811111111111114", 12, 2021)
+	resp, err := coreapi.RegisterCard("4811111111111114", 12, 2025)
 	if err != nil {
 		fmt.Println("Error register card token", err.GetMessage())
 	}
@@ -95,7 +96,7 @@ func requestCreditCard() {
 			Authentication: true,
 		},
 		Items: &[]midtrans.ItemDetails{
-			midtrans.ItemDetails{
+			{
 				ID:    "ITEM1",
 				Price: 200000,
 				Qty:   1,
@@ -106,7 +107,6 @@ func requestCreditCard() {
 
 	res, _ := c.ChargeTransaction(chargeReq)
 	fmt.Println(res)
-
 }
 
 func main() {
@@ -147,7 +147,6 @@ func main() {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{\n    \"masked_card\": \"451111-1117\",\n    \"bank\": \"bca\",\n    \"eci\": \"06\",\n    \"channel_response_code\": \"7\",\n    \"channel_response_message\": \"Denied\",\n    \"transaction_time\": \"2021-06-08 15:49:54\",\n    \"gross_amount\": \"100000.00\",\n    \"currency\": \"IDR\",\n      \"payment_type\": \"credit_card\",\n    \"signature_key\": \"76fe68ed1b7040c7c329356c1cd47819be3ccb8b056376ff3488bfa9af1db52a85ded0501b2dab1de56e5852982133a9ef7a47c54222abbe72288c2c4f591a71\",\n    \"status_code\": \"202\",\n    \"transaction_id\": \"36f3687e-05d4-4879-a428-fd6d1ffb786e\",\n    \"transaction_status\": \"deny\",\n    \"fraud_status\": \"challenge\",\n    \"status_message\": \"Success, transaction is found\",\n    \"merchant_id\": \"G812785002\",\n    \"card_type\": \"credit\"\n}"))
 	notification(w, r)
-
 }
 
 // notification : Midtrans-Go simple sample HTTP Notification handling


### PR DESCRIPTION
## Description
I'm using `coreapi` library (currently in development, and will release production version very soon)
but i can't redirect to my website page after successfully redirect in 3DS page because there is no parameter callback_type in struct `CreditCardDetails`, according to the documentation we need callback_type to Determines how the transaction status is updated to the merchant frontend.

Reference Documentation: https://api-docs.midtrans.com/#card-feature-3d-secure-3ds