### PR TITLE
add QRString field to ChargeResponse

### DIFF
--- a/coreapi/client_test.go
+++ b/coreapi/client_test.go
@@ -191,3 +191,18 @@ func TestChargeWrongServerKey(t *testing.T) {
 	c.ChargeTransaction(&ChargeReq{})
 	assert.Equal(t, err.GetStatusCode(), 401)
 }
+
+func TestChargeTransactionWithQRISIncludesQRString(t *testing.T) {
+	midtrans.ServerKey = sandboxServerKey
+	resp1, _ := ChargeTransaction(createPayload("MID-GO-UNIT_TEST-1"+timestamp(), PaymentTypeQris, ""))
+	assert.Equal(t, resp1.StatusCode, "201")
+	assert.Equal(t, resp1.PaymentType, "qris")
+	assert.NotEmpty(t, resp1.QRString)
+
+	c := Client{}
+	c.New(sandboxServerKey, midtrans.Sandbox)
+	resp2, _ := c.ChargeTransaction(createPayload("MID-GO-UNIT_TEST-2"+timestamp(), PaymentTypeQris, ""))
+	assert.Equal(t, resp2.StatusCode, "201")
+	assert.Equal(t, resp2.PaymentType, "qris")
+	assert.Empty(t, resp2.QRString)
+}

--- a/coreapi/response.go
+++ b/coreapi/response.go
@@ -59,6 +59,7 @@ type ChargeResponse struct {
 	Actions                []Action   `json:"actions"`
 	PaymentCode            string     `json:"payment_code"`
 	Store                  string     `json:"store"`
+	QRString               string     `json:"qr_string"`
 }
 
 //ApproveResponse : Approve response type when calling Midtrans approve transaction API


### PR DESCRIPTION
Added the `QRString` field to the `ChargeResponse` field as I'm trying to integrate with the API using this sdk. Apparently the current version doesn't have the QRString in the response so I cant use it for QRIS payments..

I made a test for it too but if its unnecessary or wrong let me know and I'll fix it.