### PR TITLE
update PaymentAccountResponse to correct api response structure

### DIFF
--- a/coreapi/clienttokenization_test.go
+++ b/coreapi/clienttokenization_test.go
@@ -1,10 +1,11 @@
 package coreapi
 
 import (
-	"github.com/midtrans/midtrans-go"
-	assert "github.com/stretchr/testify/require"
 	"log"
 	"testing"
+
+	"github.com/midtrans/midtrans-go"
+	assert "github.com/stretchr/testify/require"
 )
 
 /*
@@ -24,7 +25,7 @@ func initiateMidtransTokenization() {
 
 func paymentAccount(phoneNumber string) *PaymentAccountReq {
 	return &PaymentAccountReq{
-		PaymentType:  PaymentTypeGopay,
+		PaymentType: PaymentTypeGopay,
 		GopayPartner: &GopayPartnerDetails{
 			PhoneNumber: phoneNumber,
 			CountryCode: "62",
@@ -78,6 +79,7 @@ func TestLinkPaymentAccount(t *testing.T) {
 		log.Println(resp)
 		assert.Equal(t, "201", resp.StatusCode)
 		assert.NotEmpty(t, resp.AccountId)
+		assert.NotEmpty(t, resp.Actions)
 		accountId = resp.AccountId
 	}
 }
@@ -105,5 +107,3 @@ func TestUnlinkPaymentAccount(t *testing.T) {
 		assert.Equal(t, 412, err.StatusCode)
 	}
 }
-
-

--- a/coreapi/response.go
+++ b/coreapi/response.go
@@ -240,7 +240,7 @@ type PaymentAccountResponse struct {
 	AccountStatus          string                        `json:"account_status"`
 	ChannelResponseCode    string                        `json:"channel_response_code"`
 	ChannelResponseMessage string                        `json:"channel_response_message"`
-	Action                 Action                        `json:"action"`
+	Actions                []Action                      `json:"actions"`
 	Metadata               PaymentAccountMetadataDetails `json:"metadata"`
 	StatusMessage          string                        `json:"status_message"`
 	ID                     string                        `json:"id"`


### PR DESCRIPTION
Update the `Action` field of `PaymentAccountResponse` to `Actions`, a slice of `Action`. This is what is correctly returned in the Midtrans API when creating a pay account

see: https://api-docs.midtrans.com/#create-pay-account