### PR TITLE
fix installment_term json parse field

### DIFF
--- a/coreapi/response.go
+++ b/coreapi/response.go
@@ -118,7 +118,7 @@ type TransactionStatusResponse struct {
 	CustomField3           string          `json:"custom_field3"`
 	Metadata               interface{}     `json:"metadata"`
 	PaymentOptionsType     string          `json:"payment_options_type"`
-	InstallmentTerms       int             `json:"installment_terms"`
+	InstallmentTerm        int             `json:"installment_term"`
 	ThreeDsVersion         string          `json:"three_ds_version"`
 }
 


### PR DESCRIPTION
Noticed on wrong `installment_term` field in transaction_status response struct.

check status response should be like this
```
{
    "masked_card":"47737760-1650",
    "approval_code":"1662086003735",
    "bank":"bca",
    "eci":"05",
    "installment_term":24,
    "channel_response_code":"0",
    "channel_response_message":"Approved",
    "three_ds_version":"1",
    "transaction_time":"2022-09-02 09:33:08",
    "gross_amount":"230000.00",
    "currency":"IDR",
    "order_id":"03-16620858337043",
    "payment_type":"credit_card",
    "signature_key":"2f217f1356725fb227ad8b35bc6db0349021def58326f5f6f6c5d2eca572a289c1a9ae6c7cd21d54b18e529ae76c3f3ddf2fe8aa05109f94332726dad2ed3b22",
    "status_code":"200",
    "transaction_id":"f997d6ba-af8c-4d31-b159-d74f522ca5d1",
    "transaction_status":"capture",
    "fraud_status":"accept",
    "status_message":"Success, transaction is found",
    "merchant_id":"G182508043",
    "card_type":"credit"
}
```

Changed from `installment_terms` to `installment_term`

Linked issue : https://github.com/Midtrans/midtrans-go/issues/21