### PR TITLE
fix: add params into url to get iris transaction history

### DIFF
--- a/iris/client.go
+++ b/iris/client.go
@@ -174,7 +174,7 @@ func (c Client) GetTransactionHistory(fromDate string, toDate string) ([]Transac
 	jsonReq, _ := json.Marshal(`{ "from_date": ` + fromDate + `, "to_date": ` + toDate + `}`)
 	err := c.HttpClient.Call(
 		http.MethodGet,
-		fmt.Sprintf("%s/api/v1/statements", c.Env.IrisURL()),
+		fmt.Sprintf("%s/api/v1/statements?from_date=%s&to_date=%s", c.Env.IrisURL(), fromDate, toDate),
 		c.IrisApiKey,
 		c.Options,
 		bytes.NewBuffer(jsonReq),


### PR DESCRIPTION
**Back Story**
I had an issue where i cant filter out transaction by range from to date
when from_date and to_date is filled but response still has data with date out of range

after testing, i find out params is applied not from body payload but from params url

**Changes**
Add payload `from_date` and `to_date` into url