### PR TITLE
[CHEC-953] Fix BinResponse

### DIFF
--- a/coreapi/client_test.go
+++ b/coreapi/client_test.go
@@ -1,6 +1,7 @@
 package coreapi
 
 import (
+	"encoding/json"
 	"github.com/midtrans/midtrans-go"
 	assert "github.com/stretchr/testify/require"
 	"testing"
@@ -207,9 +208,82 @@ func TestChargeTransactionWithQRISIncludesQRString(t *testing.T) {
 	assert.Equal(t, resp2.PaymentType, "qris")
 	assert.NotEmpty(t, resp2.QRString)
 }
+
 func TestGetBIN(t *testing.T) {
 	midtrans.ClientKey = sandboxClientKey
 	resp, _ := GetBIN(bcaBinNumber)
 	assert.Equal(t, resp.Data.BankCode, "BCA")
 	assert.Equal(t, resp.Data.RegistrationRequired, false)
+}
+
+type mockHTTPClient struct {
+	// Define a field to hold the dummy response
+	dummyResponseJSON []byte
+}
+
+// Implement the GetBIN method of the Client interface for the mock client
+func (m *mockHTTPClient) GetBIN(binNumber string) (*BinResponse, error) {
+	// Return the stored dummy response
+	var binResponse BinResponse
+	err := json.Unmarshal(m.dummyResponseJSON, &binResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &binResponse, nil
+}
+
+func TestGetBINWithRegistrationRequiredIsNullFromResponse(t *testing.T) {
+	dummyResponseJSON := []byte(`{
+		"data": {
+			"registration_required": null,
+			"country_name": "INDONESIA",
+			"country_code": "ID",
+			"channel": "online_offline",
+			"brand": "VISA",
+			"bin_type": "CREDIT",
+			"bin_class": "GOLD",
+			"bin": "45563300",
+			"bank_code": "BCA",
+			"bank": "BANK CENTRAL ASIA"
+		}
+	}`)
+
+	// Create an instance of the mock HTTP client with the dummy response
+	mockClient := &mockHTTPClient{
+		dummyResponseJSON: dummyResponseJSON,
+	}
+
+	// Call the GetBIN function with the mock client
+	resp, err := mockClient.GetBIN(bcaBinNumber)
+
+	// Check if there's no error
+	assert.NoError(t, err)
+
+	// Check if the response matches the expected values
+	assert.Equal(t, resp.Data.BankCode, "BCA")
+	assert.Equal(t, resp.Data.RegistrationRequired, false)
+}
+
+func TestGetBINWithRegistrationRequiredIsTrueFromResponse(t *testing.T) {
+	dummyResponseJSON := []byte(`{
+		"data": {
+			"registration_required": true,
+			"country_name": "INDONESIA",
+			"country_code": "ID",
+			"channel": "online_offline",
+			"brand": "VISA",
+			"bin_type": "CREDIT",
+			"bin_class": "GOLD",
+			"bin": "45563300",
+			"bank_code": "BCA",
+			"bank": "BANK CENTRAL ASIA"
+		}
+	}`)
+	mockClient := &mockHTTPClient{
+		dummyResponseJSON: dummyResponseJSON,
+	}
+	resp, err := mockClient.GetBIN(bcaBinNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Data.BankCode, "BCA")
+	assert.Equal(t, resp.Data.RegistrationRequired, true)
 }

--- a/coreapi/client_test.go
+++ b/coreapi/client_test.go
@@ -11,6 +11,7 @@ const sandboxClientKey = "SB-Mid-client-yUgKb__vX_zH2TMN"
 const sandboxServerKey = "SB-Mid-server-TvgWB_Y9s81-rbMBH7zZ8BHW"
 const sampleCardNumber = "4811111111111114"
 const bniCardNumber = "4105058689481467"
+const bcaBinNumber = "45563300"
 
 func timestamp() string {
 	return time.Now().UTC().Format("2006010215040105")
@@ -205,4 +206,10 @@ func TestChargeTransactionWithQRISIncludesQRString(t *testing.T) {
 	assert.Equal(t, resp2.StatusCode, "201")
 	assert.Equal(t, resp2.PaymentType, "qris")
 	assert.NotEmpty(t, resp2.QRString)
+}
+func TestGetBIN(t *testing.T) {
+	midtrans.ClientKey = sandboxClientKey
+	resp, _ := GetBIN(bcaBinNumber)
+	assert.Equal(t, resp.Data.BankCode, "BCA")
+	assert.Equal(t, resp.Data.RegistrationRequired, false)
 }

--- a/coreapi/response.go
+++ b/coreapi/response.go
@@ -188,7 +188,7 @@ type CardRegisterResponse struct {
 
 type BinResponse struct {
 	Data struct {
-		RegistrationRequired string `json:"registration_required"`
+		RegistrationRequired bool   `json:"registration_required"`
 		CountryName          string `json:"country_name"`
 		CountryCode          string `json:"country_code"`
 		Channel              string `json:"channel"`


### PR DESCRIPTION
1. Fix RegistrationRequired in BinResponse data type to bool
2. add unit test for getBIN (similar to all the existing unit test where it uses real response)

when the value of `RegistrationRequired` is `null` from response, it will pass the test, in which the asserted value is `false`

> === RUN   TestGetBIN
> INFO - ================ Request ================
> INFO - GET Request https://api.sandbox.midtrans.com/v1/bins/45563300 HTTP/1.1
> INFO - user-agent: Midtrans-Go_v1.3.7
> DEBUG - authorization: Basic U0ItTWlkLWNsaWVudC15VWdLYl9fdlhfekgyVE1OOg==
> INFO - content-type: application/json
> INFO - accept: application/json
> INFO - ================== END ==================
> INFO - Request completed in 105.455458ms 
> DEBUG - =============== Response ===============
> DEBUG - date: Thu, 21 Mar 2024 08:19:35 GMT
> DEBUG - content-length: 229
> DEBUG - cache-control: max-age=0, private, must-revalidate
> DEBUG - x-request-id: b70086962438bcb9af59c8849f0c43fa
> DEBUG - access-control-allow-origin: *
> DEBUG - via: flip/flop
> DEBUG - strict-transport-security: max-age=15724800; includeSubDomains
> DEBUG - content-type: application/json; charset=utf-8
> DEBUG - x-ratelimit-limit-minute: 100
> DEBUG - x-ratelimit-remaining-minute: 99
> DEBUG - Response Body: {"data":{"registration_required":null,"country_name":"INDONESIA","country_code":"ID","channel":"online_offline","brand":"VISA","bin_type":"CREDIT","bin_class":"GOLD","bin":"45563300","bank_code":"BCA","bank":"BANK CENTRAL ASIA"}}
> --- PASS: TestGetBIN (0.11s)
> PASS
> 
> Process finished with the exit code 0 

3. added two additional unit tests with mock, where the json value can be dynamically adjusted (true/ null)

> === RUN   TestGetBINWithRegistrationRequiredIsNullFromResponse
> --- PASS: TestGetBINWithRegistrationRequiredIsNullFromResponse (0.00s)
> PASS
> 
> Process finished with the exit code 0`

> `=== RUN   TestGetBINWithRegistrationRequiredIsTrueFromResponse
> --- PASS: TestGetBINWithRegistrationRequiredIsTrueFromResponse (0.00s)
> PASS
> 
> Process finished with the exit code 0`


