### PR TITLE
fix: add other_qris to SnapPaymentType

### DIFF
--- a/midtrans.go
+++ b/midtrans.go
@@ -20,7 +20,7 @@ const (
 	Production
 
 	//libraryVersion : midtrans go library version
-	libraryVersion = "v1.3.8"
+	libraryVersion = "v1.3.9"
 )
 
 // ServerKey is config payment API key for global use

--- a/snap/paymenttype.go
+++ b/snap/paymenttype.go
@@ -72,6 +72,9 @@ const (
 
 	// PaymentTypeAlfamart : alfamart
 	PaymentTypeAlfamart SnapPaymentType = "alfamart"
+
+	// PaymentTypeOtherQris : other_qris
+	PaymentTypeOtherQris SnapPaymentType = "other_qris"
 )
 
 // AllSnapPaymentType : Get All available SnapPaymentType
@@ -99,4 +102,5 @@ var AllSnapPaymentType = []SnapPaymentType{
 	PaymentTypeAkulaku,
 	PaymentTypeAlfamart,
 	PaymentTypeConvenienceStore,
+	PaymentTypeOtherQris,
 }


### PR DESCRIPTION
We already have other_qris payment feature in Snap API
https://docs.midtrans.com/reference/other-qris

But the SnapPaymentType have not implement "other_qris" yet.

- Added `other_qris` to the SnapPaymentType to support additional QRIS payment types.
- Run test snap Api done
- Update 'libraryVersion' done

*this is my first ever open source contribution, please be gentle :)